### PR TITLE
Correctly calculate needs_rebase

### DIFF
--- a/github_pr.rb
+++ b/github_pr.rb
@@ -60,7 +60,8 @@ class GithubPr
   end
 
   def mergeable?
-    @attrs.fetch('mergeable')
+    # Github returns null for mergable while it's calculating mergability, treat PRs as mergable until proven otherwise
+    @attrs.fetch('mergeable') || @attrs.fetch('mergeable').nil?
   end
 
   def merged?


### PR DESCRIPTION
From GH API doc:
The value of the mergeable attribute can be true, false, or null. If the value is null, then GitHub has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-null value for the mergeable attribute in the response.