### PR TITLE
Improve performance of running sync

### DIFF
--- a/kanboard_project.rb
+++ b/kanboard_project.rb
@@ -2,14 +2,18 @@ require 'kanboard_resource'
 
 class KanboardProject < KanboardResource
   def current_swimlane
-    KanboardSwimlane.new(connection.request('getActiveSwimlanes', { 'project_id' => @id})[0])
+    @current_swimlane ||= KanboardSwimlane.new(connection.request('getActiveSwimlanes', { 'project_id' => @id})[0])
   end
 
   def previous_swimlane
-    KanboardSwimlane.new(connection.request('getActiveSwimlanes', { 'project_id' => @id})[2])
+    @previous_swimlane ||= KanboardSwimlane.new(connection.request('getActiveSwimlanes', { 'project_id' => @id})[2])
   end
 
-  def current_tasks(filter: '')
+  def current_tasks
+    @current_tasks ||= search_tasks(%Q(status:open swimlane:"#{current_swimlane.name}"))
+  end
+
+  def current_filtered_tasks(filter: '')
     search_tasks(%Q(status:open swimlane:"#{current_swimlane.name}" #{filter}))
   end
 

--- a/kanboard_task.rb
+++ b/kanboard_task.rb
@@ -34,11 +34,11 @@ class KanboardTask < KanboardResource
   end
 
   def redmine_links
-    external_links.select { |link| link.url.include?(REDMINE_URL)}
+    @redmine_links ||= external_links.select { |link| link.url.include?(REDMINE_URL)}
   end
 
   def redmine_issues
-    redmine_links.map do |link|
+    @redmine_issues ||= redmine_links.map do |link|
       RedmineIssue.new(link.url)
     end
   end
@@ -48,7 +48,7 @@ class KanboardTask < KanboardResource
   end
 
   def github_links
-    external_links.select { |link| link.url.include?(GITHUB_URL)}
+    @github_links ||= external_links.select { |link| link.url.include?(GITHUB_URL)}
   end
 
   def bugzilla_links?
@@ -56,7 +56,7 @@ class KanboardTask < KanboardResource
   end
 
   def bugzilla_links
-    external_links.select { |link| link.url.include?(BUGZILLA_URL)}
+    @bugzilla_links ||= external_links.select { |link| link.url.include?(BUGZILLA_URL)}
   end
 
   def bugzilla_ids
@@ -64,7 +64,7 @@ class KanboardTask < KanboardResource
   end
 
   def bugzillas
-    bugzila_links.map { |link| Bugzilla.load(link) }
+    @bugzillas ||= bugzila_links.map { |link| Bugzilla.load(link) }
   end
 
   def sync_bugzilla_links
@@ -98,7 +98,7 @@ class KanboardTask < KanboardResource
   end
 
   def external_links
-    connection.request('getAllExternalTaskLinks', { 'task_id' => @id }).map do |attrs|
+    @external_links ||= connection.request('getAllExternalTaskLinks', { 'task_id' => @id }).map do |attrs|
       KanboardExternalLink.new(attrs)
     end
   end
@@ -128,7 +128,7 @@ class KanboardTask < KanboardResource
   end
 
   def tags
-    connection.request('getTaskTags', [@id]).map(&:last)
+    @tags ||= connection.request('getTaskTags', [@id]).map(&:last)
   end
 
   def set_tags(tags)
@@ -137,6 +137,6 @@ class KanboardTask < KanboardResource
   end
 
   def owner
-    KanboardUser.find_by_id(self.owner_id)
+    @owner ||= KanboardUser.find_by_id(self.owner_id)
   end
 end

--- a/kanboard_user.rb
+++ b/kanboard_user.rb
@@ -2,7 +2,7 @@ require 'kanboard_resource'
 
 class KanboardUser < KanboardResource
   def self.find_by_name(name)
-    user = connection.request('getAllUsers').find { |u| u['name'] == name }
+    user = all_users.find { |u| u['name'] == name }
     if user.nil?
       Kansync.logger.error "Kanboard user with name #{name} not found, consider specifying mapping for this name"
       return nil
@@ -19,5 +19,9 @@ class KanboardUser < KanboardResource
     else
       new user
     end
+  end
+
+  def self.all_users
+    @all_users ||= connection.request('getAllUsers')
   end
 end

--- a/request_factory.rb
+++ b/request_factory.rb
@@ -4,6 +4,7 @@ class RequestFactory
     @user = connection_options['user']
     @pw = connection_options['pw']
     @counter = 0
+    @logger = Kansync.logger
     @connection = Faraday.new(:url => @url) do |faraday|
       # faraday.response :logger
       faraday.basic_auth(@user, @pw)
@@ -20,13 +21,14 @@ class RequestFactory
         'method' => method,
     }
     body.merge!('params' => params) unless params.nil?
-
+# start = Time.now
+# @logger.debug "starting request #{method} with params #{body}"
     response = @connection.post do |req|
       req.url '/jsonrpc.php'
       req.headers['Content-Type'] = 'application/json'
       req.body = body.to_json
     end
-
+# @logger.debug "request #{method} finished in #{Time.now-start}"
     parsed_body = JSON.parse(response.body)
     if parsed_body['result']
       return parsed_body['result']

--- a/task_runner.rb
+++ b/task_runner.rb
@@ -24,13 +24,15 @@ class TaskRunner
       tasks.sort!
     end
 
+    project = KanboardProject.new('id' => project_id)
     tasks.each do |task|
-      project = KanboardProject.new('id' => project_id)
       task_configuration = profile.task_configuration.fetch(task_name(task), {})
 
       logger.info "Starting task #{task}"
+      start = Time.now
       instance_eval File.read(task), task, 1
-      logger.info "Finished task #{task}\n"
+      finish = Time.now
+      logger.info "Finished task #{task} in #{finish-start} seconds\n"
     end
   end
 

--- a/tasks/070-sync_redmine_link_from_github.rb
+++ b/tasks/070-sync_redmine_link_from_github.rb
@@ -10,23 +10,23 @@ github_password = @profile.github_options['password']
 project.current_tasks.each do |task|
   logger.info "Processing #{task.title}"
 
-  if task.github_links?
-    task.github_links.each do |github_link|
-      begin
-        pr = GithubPr.new(github_link.url, github_username, github_password)
-      rescue
-        logger.error "invalid github URL #{github_link.url}, skipping"
-        next
-      end
+  redmine_links = task.redmine_links
 
-      if (issue = pr.redmine_issue)
-        unless task.redmine_links.map(&:url).include?(issue.url)
-          logger.warn "Adding redmine link #{issue.url}"
-          task.create_redmine_links(issue.url)
-        end
-      else
-        logger.debug "No redmine issue found for #{github_link.url}"
+  task.github_links.each do |github_link|
+    begin
+      pr = GithubPr.new(github_link.url, github_username, github_password)
+    rescue
+      logger.error "invalid github URL #{github_link.url}, skipping"
+      next
+    end
+
+    if (issue = pr.redmine_issue)
+      unless redmine_links.map(&:url).include?(issue.url)
+        logger.warn "Adding redmine link #{issue.url}"
+        task.create_redmine_links(issue.url)
       end
+    else
+      logger.debug "No redmine issue found for #{github_link.url}"
     end
   end
 end

--- a/tasks/400-sync_bz_bugs_to_triage.rb
+++ b/tasks/400-sync_bz_bugs_to_triage.rb
@@ -34,7 +34,7 @@ default_configuration = {
 
 task_configuration = default_configuration.deep_merge(task_configuration)
 
-existing_triage_tasks = project.current_tasks(filter: "tag:\"#{task_configuration['tag']}\"")
+existing_triage_tasks = project.current_filtered_tasks(filter: "tag:\"#{task_configuration['tag']}\"")
 existing_triage_bzs = existing_triage_tasks.map do |task|
   task.bugzilla_ids
 end.flatten.uniq


### PR DESCRIPTION
This commit caches many repeated API calls, reducing the overall runtime
from 8 minutes to under 3 minutes for a board with 31 tasks on it.